### PR TITLE
HistoryManager Collaboration

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -754,7 +754,9 @@ protected
   # shell_write instead of operating on rstream directly.
   def _interact
     framework.events.on_session_interact(self)
-    _interact_stream
+    Rex::Ui::Text::Shell::HistoryManager.with_context(name: self.type.to_sym) {
+      _interact_stream
+    }
   end
 
   ##

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -546,9 +546,9 @@ class CommandShell
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"self\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.push_context(name: :irb)
-      Rex::Ui::Text::IrbShell.new(self).run
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
+      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+        Rex::Ui::Text::IrbShell.new(self).run
+      end
     else
       # XXX: No vprint_status here
       if framework.datastore['VERBOSE'].to_s == 'true'
@@ -585,9 +585,9 @@ class CommandShell
     print_status('Starting Pry shell...')
     print_status("You are in the \"self\" (session) object\n")
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
-    self.pry
-    Rex::Ui::Text::Shell::HistoryManager.pop_context
+    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+      self.pry
+    end
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -584,9 +584,8 @@ class CommandShell
 
     print_status('Starting Pry shell...')
     print_status("You are in the \"self\" (session) object\n")
-    histfile = Msf::Config.pry_history
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: histfile,name: :pry)
+    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
     self.pry
     Rex::Ui::Text::Shell::HistoryManager.pop_context
   end

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -28,13 +28,6 @@ module Interactive
     super()
   end
 
-  def interact(*args)
-    history_context = {
-      history_file: type == 'meterpreter' ? Msf::Config.meterpreter_history : nil,
-      name: type.to_sym
-    }
-    super(*args, history_context: history_context)
-  end
   #
   # Returns that, yes, indeed, this session supports going interactive with
   # the user.

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -106,7 +106,7 @@ protected
   #
   # Stub method that is meant to handler interaction.
   #
-  def _interact   
+  def _interact
     framework.events.on_session_interact(self)
   end
 

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -110,19 +110,19 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     if expressions.empty?
       print_status('Starting IRB shell...')
 
-      Rex::Ui::Text::Shell::HistoryManager.push_context(name: :irb)
-      begin
-        if active_module
-          print_status("You are in #{active_module.fullname}\n")
-          Rex::Ui::Text::IrbShell.new(active_module).run
-        else
-          print_status("You are in the \"framework\" object\n")
-          Rex::Ui::Text::IrbShell.new(framework).run
+      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+        begin
+          if active_module
+            print_status("You are in #{active_module.fullname}\n")
+            Rex::Ui::Text::IrbShell.new(active_module).run
+          else
+            print_status("You are in the \"framework\" object\n")
+            Rex::Ui::Text::IrbShell.new(framework).run
+          end
+        rescue
+          print_error("Error during IRB: #{$!}\n\n#{$@.join("\n")}")
         end
-      rescue
-        print_error("Error during IRB: #{$!}\n\n#{$@.join("\n")}")
       end
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
 
       # Reset tab completion
       if (driver.input.supports_readline)
@@ -173,16 +173,15 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     print_status('Starting Pry shell...')
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
-    if active_module
-      print_status("You are in the \"#{active_module.fullname}\" module object\n")
-      active_module.pry
-    else
-      print_status("You are in the \"framework\" object\n")
-      framework.pry
+    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+      if active_module
+        print_status("You are in the \"#{active_module.fullname}\" module object\n")
+        active_module.pry
+      else
+        print_status("You are in the \"framework\" object\n")
+        framework.pry
+      end
     end
-
-    Rex::Ui::Text::Shell::HistoryManager.pop_context
   end
 
   def cmd_edit_help

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -110,8 +110,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     if expressions.empty?
       print_status('Starting IRB shell...')
 
-      begin
       Rex::Ui::Text::Shell::HistoryManager.push_context(name: :irb)
+      begin
         if active_module
           print_status("You are in #{active_module.fullname}\n")
           Rex::Ui::Text::IrbShell.new(active_module).run
@@ -119,10 +119,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
           print_status("You are in the \"framework\" object\n")
           Rex::Ui::Text::IrbShell.new(framework).run
         end
-        Rex::Ui::Text::Shell::HistoryManager.pop_context
       rescue
         print_error("Error during IRB: #{$!}\n\n#{$@.join("\n")}")
       end
+      Rex::Ui::Text::Shell::HistoryManager.pop_context
 
       # Reset tab completion
       if (driver.input.supports_readline)
@@ -169,20 +169,20 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       print_error('Failed to load Pry, try "gem install pry"')
       return
     end
-    histfile = Msf::Config.pry_history
-    Pry.config.history_load = false
+
     print_status('Starting Pry shell...')
 
-    unless active_module
+    Pry.config.history_load = false
+    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
+    if active_module
+      print_status("You are in the \"#{active_module.fullname}\" module object\n")
+      active_module.pry
+    else
       print_status("You are in the \"framework\" object\n")
-      Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: histfile,name: :pry)
       framework.pry
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
-      return
     end
 
-    print_status("You are in #{active_module.fullname}\n")
-    active_module.pry
+    Rex::Ui::Text::Shell::HistoryManager.pop_context
   end
 
   def cmd_edit_help

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -79,7 +79,6 @@ class Driver < Msf::Ui::Driver
 
     # Call the parent
     super(prompt, prompt_char, histfile, framework, :msfconsole)
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: histfile, name: :msfconsole)
 
     # Temporarily disable output
     self.disable_output = true

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -78,7 +78,8 @@ class Driver < Msf::Ui::Driver
     end
 
     # Call the parent
-    super(prompt, prompt_char, histfile, framework)
+    super(prompt, prompt_char, histfile, framework, :msfconsole)
+    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: histfile, name: :msfconsole)
 
     # Temporarily disable output
     self.disable_output = true

--- a/lib/msf/ui/console/framework_event_manager.rb
+++ b/lib/msf/ui/console/framework_event_manager.rb
@@ -44,7 +44,6 @@ module FrameworkEventManager
   # Called when a session is closed and removed from the framework.
   #
   def on_session_close(session, reason='')
-    Rex::Ui::Text::Shell::HistoryManager.pop_context if session.type != 'meterpreter'
     if (session.interacting == true)
       output.print_line
     end

--- a/lib/rex/post/hwbridge/ui/console.rb
+++ b/lib/rex/post/hwbridge/ui/console.rb
@@ -52,8 +52,6 @@ class Console
   # assumed that init_ui has been called prior.
   #
   def interact(&block)
-    init_tab_complete
-
     # Run queued commands
     commands.delete_if { |ent|
       run_single(ent)

--- a/lib/rex/post/meterpreter/ui/console.rb
+++ b/lib/rex/post/meterpreter/ui/console.rb
@@ -52,8 +52,6 @@ class Console
   # assumed that init_ui has been called prior.
   #
   def interact(&block)
-    init_tab_complete
-
     # Run queued commands
     commands.delete_if { |ent|
       run_single(ent)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -582,9 +582,9 @@ class Console::CommandDispatcher::Core
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"client\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.push_context(name: :irb)
-      Rex::Ui::Text::IrbShell.new(client).run
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
+      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+        Rex::Ui::Text::IrbShell.new(client).run
+      end
     else
       # XXX: No vprint_status here
       if framework.datastore['VERBOSE'].to_s == 'true'
@@ -622,9 +622,9 @@ class Console::CommandDispatcher::Core
     print_status("You are in the \"client\" (session) object\n")
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
-    client.pry
-    Rex::Ui::Text::Shell::HistoryManager.pop_context
+    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+      client.pry
+    end
   end
 
   @@set_timeouts_opts = Rex::Parser::Arguments.new(

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -620,9 +620,9 @@ class Console::CommandDispatcher::Core
 
     print_status('Starting Pry shell...')
     print_status("You are in the \"client\" (session) object\n")
-    histfile = Msf::Config.pry_history
+
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: histfile,name: :pry)
+    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: Msf::Config.pry_history, name: :pry)
     client.pry
     Rex::Ui::Text::Shell::HistoryManager.pop_context
   end

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -21,10 +21,10 @@ module Interactive
   # forwarding input from user_input to rstream and forwarding input from
   # rstream to user_output.
   #
-  def interact(user_input, user_output, history_context: {:history_file => nil, :name => nil})
+  def interact(user_input, user_output, history_context: { :history_file => nil, :name => nil })
 
     # Detach from any existing console
-    if(self.interacting)
+    if self.interacting
       detach()
     end
 
@@ -76,11 +76,13 @@ module Interactive
       _interact_complete if (eof == true)
 
       # Shutdown the readline thread
- 			# XXX disabled
+      # XXX disabled
       # user_input.readline_stop() if user_input.supports_readline
 
       # Detach from the input/output handles
       reset_ui()
+
+      Rex::Ui::Text::Shell::HistoryManager.pop_context
 
     ensure
       # Mark this as completed

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -21,14 +21,12 @@ module Interactive
   # forwarding input from user_input to rstream and forwarding input from
   # rstream to user_output.
   #
-  def interact(user_input, user_output, history_context: { :history_file => nil, :name => nil })
+  def interact(user_input, user_output)
 
     # Detach from any existing console
     if self.interacting
       detach()
     end
-
-    Rex::Ui::Text::Shell::HistoryManager.push_context(**history_context)
 
     init_ui(user_input, user_output)
 
@@ -81,8 +79,6 @@ module Interactive
 
       # Detach from the input/output handles
       reset_ui()
-
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
 
     ensure
       # Mark this as completed

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -28,11 +28,7 @@ module Interactive
       detach()
     end
 
-    history_file = history_context[:history_file]
-    name = history_context[:name]
-
-    Rex::Ui::Text::Shell::HistoryManager.push_context(history_file: history_file, name: name)
-
+    Rex::Ui::Text::Shell::HistoryManager.push_context(**history_context)
 
     init_ui(user_input, user_output)
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -349,7 +349,7 @@ module DispatcherShell
   #
   # Initialize the dispatcher shell.
   #
-  def initialize(prompt, prompt_char = '>', histfile = nil, framework = nil, name = :msfconsole)
+  def initialize(prompt, prompt_char = '>', histfile = nil, framework = nil, name = nil)
     super
 
     # Initialze the dispatcher array

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -37,7 +37,6 @@ module Shell
     end
   end
 
-  @@last_console = :msfconsole
   #
   # Initializes a shell that has a prompt and can be interacted with.
   #
@@ -65,11 +64,6 @@ module Shell
   end
 
   def init_tab_complete
-
-    if @@last_console == :meterpreter && name == :msfconsole
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
-    end
-    @@last_console = self.name 
     if (self.input and self.input.supports_readline)
       # Unless cont_flag because there's no tab complete for continuation lines
       self.input = Input::Readline.new(lambda { |str| tab_complete(str) unless cont_flag })

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -67,12 +67,6 @@ module Shell
     if (self.input and self.input.supports_readline)
       # Unless cont_flag because there's no tab complete for continuation lines
       self.input = Input::Readline.new(lambda { |str| tab_complete(str) unless cont_flag })
-      if Readline::HISTORY.length == 0 and histfile and File.exist?(histfile)
-        File.readlines(histfile).each { |e|
-          Readline::HISTORY << e.chomp
-        }
-        self.hist_last_saved = Readline::HISTORY.length
-      end
       self.input.output = self.output
     end
   end
@@ -129,6 +123,9 @@ module Shell
   #
   def run(&block)
 
+    HistoryManager.push_context(history_file: histfile, name: name)
+    self.hist_last_saved = Readline::HISTORY.length
+
     begin
 
       while true
@@ -152,16 +149,10 @@ module Shell
         elsif block
           break if block.call(line)
 
-        # Otherwise, call what should be an overriden instance method to
+        # Otherwise, call what should be an overridden instance method to
         # process the line.
         else
-          ret = run_single(line)
-          # don't bother saving lines that couldn't be found as a
-          # command, create the file if it doesn't exist, don't save dupes
-          if ret && self.histfile && line != @last_line
-            File.open(self.histfile, 'a+') { |f| f.puts(line) }
-            @last_line = line
-          end
+          run_single(line)
           self.stop_count = 0
         end
 
@@ -170,6 +161,9 @@ module Shell
     rescue ::Interrupt
       output.print("Interrupt: use the 'exit' command to quit\n")
       retry
+    ensure
+      HistoryManager.pop_context
+      self.hist_last_saved = Readline::HISTORY.length
     end
   end
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -40,7 +40,7 @@ module Shell
   #
   # Initializes a shell that has a prompt and can be interacted with.
   #
-  def initialize(prompt, prompt_char = '>', histfile = nil, framework = nil, name = :msfconsole)
+  def initialize(prompt, prompt_char = '>', histfile = nil, framework = nil, name = nil)
     # Set the stop flag to false
     self.stop_flag      = false
     self.disable_output = false
@@ -145,7 +145,7 @@ module Shell
         if input.eof? || line == nil
           self.stop_count += 1
           next if self.stop_count > 1
-          run_single("quit")
+          run_single('quit')
 
         # If a block was passed in, pass the line to it.  If it returns true,
         # break out of the shell loop.
@@ -159,7 +159,7 @@ module Shell
           # don't bother saving lines that couldn't be found as a
           # command, create the file if it doesn't exist, don't save dupes
           if ret && self.histfile && line != @last_line
-            File.open(self.histfile, "a+") { |f| f.puts(line) }
+            File.open(self.histfile, 'a+') { |f| f.puts(line) }
             @last_line = line
           end
           self.stop_count = 0

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -7,7 +7,7 @@ module Shell
 
 class HistoryManager
 
-  @@contexts = [{:history_file => Msf::Config.history_file, :name => :msfconsole}]
+  @@contexts = []
 
   def self.inspect
     "#<HistoryManager stack size: #{@@contexts.length}>"

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -6,10 +6,9 @@ module Text
 module Shell
 
 class HistoryManager
- 
 
   @@contexts = [{:history_file => Msf::Config.history_file, :name => :msfconsole}]
-  
+
   def self.inspect
     "#<HistoryManager stack size: #{@@contexts.length}>"
   end
@@ -28,31 +27,32 @@ class HistoryManager
 
   def self.pop_context
     if @@contexts.empty?
-      elog("`pop_context' called even when the stack was already empty!")
+      elog("`#pop_context' called even when the stack was already empty!")
       return
     end
     history_file, name = @@contexts.pop.values
     if history_file
       cmds = []
       history_diff = Readline::HISTORY.size - @@original_histsize
-      history_diff.times do 
+      history_diff.times do
         cmds.push(Readline::HISTORY.pop)
       end
-      File.open(history_file, "a+") { |f| 
-        f.puts(cmds.reverse) }
+      File.open(history_file, 'a+') do |f|
+        f.puts(cmds.reverse)
+      end
     end
     clear_readline
   end
 
   class << self
     private
-  
+
     def set_history_file(history_file)
       clear_readline
       if File.exist?(history_file)
-        File.readlines(history_file).each { |e|
+        File.readlines(history_file).each do |e|
           Readline::HISTORY << e.chomp
-        }
+        end
         @@original_histsize = Readline::HISTORY.size
       else
         @@original_histsize = 0
@@ -60,7 +60,7 @@ class HistoryManager
     end
 
     def clear_readline
-      Readline::HISTORY.length.times {Readline::HISTORY.pop}
+      Readline::HISTORY.length.times { Readline::HISTORY.pop }
     end
 
   end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -44,6 +44,16 @@ class HistoryManager
     clear_readline
   end
 
+  def self.with_context(**kwargs, &block)
+    self.push_context(**kwargs)
+
+    begin
+      block.call
+    ensure
+      self.pop_context
+    end
+  end
+
   class << self
     private
 


### PR DESCRIPTION
Alright this changes a few things.

# HistoryManager Changes
## Logging Output
Context changes are now logged at the debug level. This means you can watch what it's doing by monitoring `~/.msf4/logs/framework` which helps for debugging to ensure consistency.

## Adds #with_context
Adding the `#with_context` method makes it easier for the caller to leverage an `ensure` block to guarantee that the context that was pushed to the stack is removed even if there's an exception. This fixes a bug where if an IRB shell encounters exits out due to an error, the context stack would still have it's entry.

## Adds and uses #switch_context
Added the `#switch_context` method to the `HistoryManager` class which, handles the operations necessary to change from one context to another. This provides an opportunity to write the previous history file to disk and load the new one regardless of if the context is changing due to either a push or pop operation. In addition to that, it simplifies the logic within the push and pop methods because now they only need to calculate the new and old contexts.

## Replaces #set_history_file with #load_history_file and #store_history_file
The "set" verb was a little too ambiguous for my taste, but also adding the `#store_history_file` method made the `#switch_context` method a little easier to read. This was basically a refactor of the existing code.

# Context Change Points
I changed a few of the points at which the context is changed. This refined the existing work to reduce the number of points. Now the shell (and derivatives) and meterpreter sessions use separate locations. Both meterpreter and msfconsole rely on the `#run` method in `Rex::Ui::Text::Shell`. Since shell sessions though don't use `Rex::Ui::Text::Shell`, their `#_interact` method was used as the context change point. Other sessions like VNC don't make sense to update the context since their UI is not text based.

The new HistoryManager is also responsible for writing the msfconsole history file now as well. The previously used code was removed since it's now redundant.

# MakeRC
Prior to using this new history manager, the `makerc` command had a bug in it where it would write out Meterpreter commands inter-mixed with msfconsole commands. This resulted in a resource file that would error out on those when loaded into msfconsole. Due to how the context is changed, this is now fixed.

# Testing
I tested this pretty thoroughly. Here are some of the specific things I looked for. Feel free to test as well.

* The `makerc` command works before and after a context change
* The context stack is correct throughout usage of msfconsole, meterpreter, shell, pry, and irb
    * The stack is still correct when using the `sessions` command inside of meterpreter
    * The stack is still correct when a meterpreter session dies while being interacted with
    * The stack is still correct with an IRB shell is exited due to an unhandled exception
* Each of the respective history files are correctly written to