### PR TITLE
adjust history context to thread file write

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -166,6 +166,7 @@ module Shell
       retry
     ensure
       HistoryManager.pop_context
+      HistoryManager.flush
       self.hist_last_saved = Readline::HISTORY.length
     end
   end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -62,7 +62,7 @@ class HistoryManager
     def load_history_file(history_file)
       clear_readline
       if commands = from_storage_queue(history_file)
-        commands.each do |c|
+        commands.reverse.each do |c|
           Readline::HISTORY << c
         end
       else

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -52,6 +52,10 @@ class HistoryManager
     end
   end
 
+  def self.flush
+    sleep 0.1 until @@write_queue.empty?
+  end
+
   class << self
     private
 

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -12,7 +12,7 @@ class HistoryManager
   @@contexts = []
 
   @@write_mutex = Mutex.new
-  @@write_quewue = {}
+  @@write_queue = {}
 
   def self.inspect
     "#<HistoryManager stack size: #{@@contexts.length}>"
@@ -100,7 +100,7 @@ class HistoryManager
 
     def write_history_file(history_file, cmds)
       @@write_mutex.synchronize do
-        @@write_quewue[history_file] = cmds
+        @@write_queue[history_file] = cmds
       end
 
       Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
@@ -109,14 +109,14 @@ class HistoryManager
         end
 
         @@write_mutex.synchronize do
-          @@write_quewue.delete(history_file)
+          @@write_queue.delete(history_file)
         end
       end
     end
 
     def from_storage_queue(history_file)
       @@write_mutex.synchronize do
-        @@write_quewue[history_file]
+        @@write_queue[history_file]
       end
     end
   end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -104,7 +104,7 @@ class HistoryManager
       end
 
       Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
-        File.open(history_file, 'a+') do |f|
+        File.open(history_file, 'w+') do |f|
           f.puts(cmds.reverse)
         end
 


### PR DESCRIPTION
By moving writes to a thread and allowing short circuit when
a context is reloaded quickly this code can shorten the conditions
that would cause slow context transitions.  This also restricts
history length to a defined constant applied to each context.

Note: This needs thorough testing to ensure `mutex` protections are correctly placed.